### PR TITLE
chore : reverted all changes back to v2.5 and added checks along with…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Checkout (platform)
         uses: actions/checkout@v3
         with:
-          repository: jalantechnologies/github-ci
+          repository: Team-A7/github-ci
           path: platform
           ref: ${{ steps.ci_workflow.outputs.version }}
 
@@ -183,7 +183,7 @@ jobs:
       - name: Checkout (platform)
         uses: actions/checkout@v3
         with:
-          repository: jalantechnologies/github-ci
+          repository: Team-A7/github-ci
           path: platform
           ref: ${{ steps.ci_workflow.outputs.version }}
 
@@ -231,7 +231,7 @@ jobs:
       - name: Checkout (platform)
         uses: actions/checkout@v3
         with:
-          repository: jalantechnologies/github-ci
+          repository: Team-A7/github-ci
           path: platform
           ref: ${{ needs.build.outputs.workflow_ci_version }}
 
@@ -250,7 +250,7 @@ jobs:
           docker_password: ${{ secrets.docker_password }}
 
   deploy:
-    needs: build
+    needs: [build,checks]
     runs-on: ubuntu-latest
     outputs:
       url: ${{ steps.deploy.outputs.url }}
@@ -263,7 +263,7 @@ jobs:
       - name: Checkout (platform)
         uses: actions/checkout@v3
         with:
-          repository: jalantechnologies/github-ci
+          repository: Team-A7/github-ci
           path: platform
           ref: ${{ needs.build.outputs.workflow_ci_version }}
 

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout (platform)
         uses: actions/checkout@v3
         with:
-          repository: jalantechnologies/github-ci
+          repository: Team-A7/github-ci
           path: platform
           ref: ${{ steps.ci_workflow.outputs.version }}
 


### PR DESCRIPTION
**Why this changes require**
Previously, the pipeline was configured to run the deploy stage as long as the build stage succeeded. This caused an issue where, even if test cases failed, the deployment stage would still execute. As a result, deployments would fail unnecessarily and consume additional GitHub Actions minutes.

**Also i had reverted all changes to v2.5 which  removed all local temporal dashboard configuration from workflow file , as we are using cloud related temporal dashboard**

**Change Introduced**

- This update modifies the pipeline so that the deploy stage now depends on both the build and checks stages.
- Deployment will only run if both build and test cases pass.If test cases fail, the deploy stage will be skipped automatically, saving GitHub Actions minutes and avoiding unnecessary failed deployments.
- Removed temporal dashboard related configuration

**Manual Test Cases**

**1)PR with failing test cases**

- Raised a PR from the test branch with base branch namra/chore/added_deploy_condition.
- Pipeline triggered → build succeeded → test cases failed.
- Result: Deploy stage was skipped, preventing wasted deployment runs.
<img width="1918" height="877" alt="Screenshot 2025-09-16 203722" src="https://github.com/user-attachments/assets/82211d67-f03a-4c7d-b5d0-b703acfb8305" />

**2)PR with passing the test cases**

- Raised a PR from the test branch with base branch namra/chore/added_deploy_conditions.
- Pipeline triggered → build succeeded → test cases passes.
- Result: Deploy stage was executed succesfully as a result pipeline run succesfully .
<img width="1918" height="877" alt="image" src="https://github.com/user-attachments/assets/071901f4-066c-4915-aae8-8fa94a4b4a23" />

**3)deploy job has now no stuff related temporal dashboard**
<img width="1832" height="738" alt="image" src="https://github.com/user-attachments/assets/2dfac038-628b-4276-8a4b-c22a8ede0c50" />



**Changes Made in repo**

- **In CI workflow file in deploy job along with build job i had add dependencies of checks also. There by deploy job will depend on both build and checks for triggering if any one fail deploy job will be skipped**

<img width="479" height="190" alt="image" src="https://github.com/user-attachments/assets/dd8f5213-4867-49ee-a73a-8588dbe5ec5b" />



- **updated the repository path with Team-A7/github-ci to use that workflow instead of jalantechnologies/github-ci**


<img width="875" height="556" alt="image" src="https://github.com/user-attachments/assets/e44dfff9-652b-4c64-adb4-699d541f4c5a" />


