### PR TITLE
feat: show web app url and temporal namespace in pr deploy comment

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -185,4 +185,5 @@ runs:
         hide_classify: "OUTDATED"
         number: ${{ inputs.pull_request_number }}
         message: |
-          Deployment (${{ inputs.app_name }}) is available at - ${{ steps.deploy.outputs.url }}
+          **Web app deployment:** ${{ steps.deploy.outputs.url }}
+          **Temporal Cloud namespace:** `${{ env.TEMPORAL_PREVIEW_NAMESPACE }}`

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -185,5 +185,5 @@ runs:
         hide_classify: "OUTDATED"
         number: ${{ inputs.pull_request_number }}
         message: |
-          Web app deployment: ${{ steps.deploy.outputs.url }}
+          Web App deployment: ${{ steps.deploy.outputs.url }}
           Temporal Cloud namespace: https://cloud.temporal.io/namespaces/${{ env.TEMPORAL_PREVIEW_NAMESPACE }}/workflows

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -186,4 +186,4 @@ runs:
         number: ${{ inputs.pull_request_number }}
         message: |
           Web app deployment: ${{ steps.deploy.outputs.url }}
-          Temporal Cloud namespace: `${{ env.TEMPORAL_PREVIEW_NAMESPACE }}`
+          Temporal Cloud namespace: https://cloud.temporal.io/namespaces/${{ env.TEMPORAL_PREVIEW_NAMESPACE }}/workflows

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -185,5 +185,5 @@ runs:
         hide_classify: "OUTDATED"
         number: ${{ inputs.pull_request_number }}
         message: |
-          **Web app deployment:** ${{ steps.deploy.outputs.url }}
-          **Temporal Cloud namespace:** `${{ env.TEMPORAL_PREVIEW_NAMESPACE }}`
+          Web app deployment: ${{ steps.deploy.outputs.url }}
+          Temporal Cloud namespace: `${{ env.TEMPORAL_PREVIEW_NAMESPACE }}`


### PR DESCRIPTION
## Description
Updates the sticky PR comment posted after a preview deployment to show the web app URL and Temporal Cloud namespace as separate labelled lines, replacing the generic `Deployment (app-name) is available at - ...` format.

## Database schema changes
None.

## Tests
### Automated test cases added
None.

### Manual test cases run
- Triggered a preview deployment on LIFT-AI and confirmed the PR comment shows both the web app URL and Temporal Cloud namespace correctly.

https://github.com/Team-A7/LIFT-AI/pull/969#issuecomment-4458621934